### PR TITLE
Deduplicate docs and note branch naming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,3 +50,7 @@
 - For system tests: Google Chrome is required
 - Environment variables: Check `.env.example` if available
 
+## Branch Naming
+- Use descriptive branch names written in English
+- Avoid Japanese or other non‑ASCII characters in branch names
+

--- a/docs/email_system_implementation_report.md
+++ b/docs/email_system_implementation_report.md
@@ -6,93 +6,16 @@
 ## 実装概要
 360度評価システムに包括的なメール通知機能を実装しました。この機能により、評価プロセス全体を通じて参加者と管理者に自動的に通知を送信できます。
 
-## 実装された機能
+## 主な実装内容
+- メーラー `EvaluationMailer` の追加
+- HTML/テキストメールテンプレート実装
+- コントローラーへのメール送信統合
+- `config/locales/ja.yml` への翻訳追加
+- リマインダー送信用ジョブとRakeタスク
+- メーラープレビュー用ファイル
 
-### ✅ 1. メーラークラス
-- **ファイル**: `app/mailers/evaluation_mailer.rb`
-- **機能**:
-  - `invitation(evaluation_participant)` - 評価招待メール
-  - `reminder(evaluation_participant)` - リマインダーメール
-  - `completion_notification(evaluation)` - 完了通知メール
-
-### ✅ 2. メールテンプレート
-プロフェッショナルなHTML・テキストテンプレートを6ファイル実装：
-
-**HTMLテンプレート（レスポンシブデザイン対応）**
-- `app/views/evaluation_mailer/invitation.html.erb`
-- `app/views/evaluation_mailer/reminder.html.erb`
-- `app/views/evaluation_mailer/completion_notification.html.erb`
-
-**テキストテンプレート（アクセシビリティ対応）**
-- `app/views/evaluation_mailer/invitation.text.erb`
-- `app/views/evaluation_mailer/reminder.text.erb`
-- `app/views/evaluation_mailer/completion_notification.text.erb`
-
-**デザイン特徴**
-- インラインCSS使用でメールクライアント互換性確保
-- カラーコード別ヘッダー（招待:青、リマインダー:オレンジ、完了:緑）
-- グラデーション効果とプロフェッショナルなスタイリング
-- ホバーエフェクト付きCTAボタン
-- 統計表示ダッシュボード（完了通知）
-
-### ✅ 3. コントローラー統合
-- **ファイル**: `app/controllers/evaluation_participants_controller.rb`
-- **変更**: コメントアウトされていたメール送信機能を有効化
-- **機能**:
-  - 個別参加者追加時の自動招待メール送信
-  - 一括参加者追加時の自動招待メール送信
-
-### ✅ 4. 国際化（i18n）対応
-- **ファイル**: `config/locales/ja.yml`
-- **追加内容**:
-  - `evaluation_mailer.invitation.*` - 招待メール翻訳
-  - `evaluation_mailer.reminder.*` - リマインダーメール翻訳
-  - `evaluation_mailer.completion_notification.*` - 完了通知翻訳
-  - `evaluation_mailer.common.*` - 共通翻訳（役割、ステータス）
-
-### ✅ 5. バックグラウンドジョブ
-- **ファイル**: `app/jobs/evaluation_reminder_job.rb`
-- **機能**:
-  - 期限が近い評価の自動リマインダー送信
-  - 個別・一括リマインダー送信対応
-  - エラーハンドリングとログ記録
-
-### ✅ 6. モデル拡張
-- **ファイル**: `app/models/evaluation_participant.rb`
-- **追加メソッド**: `needs_reminder?`
-- **機能**: リマインダーが必要かどうかの判定ロジック
-
-### ✅ 7. 開発環境設定
-- **ファイル**: `config/environments/development.rb`
-- **変更**: SMTP設定を有効化（localhost:1025）
-- **機能**: 開発環境でのメール送信テスト対応
-
-### ✅ 8. メーラープレビュー
-- **ファイル**: `test/mailers/previews/evaluation_mailer_preview.rb`
-- **機能**:
-  - 開発中のメールテンプレート確認
-  - サンプルデータ自動生成
-  - 3つのメールタイプすべてプレビュー対応
-
-### ✅ 9. Rakeタスク
-- **ファイル**: `lib/tasks/evaluation.rake`
-- **タスク**:
-  - `evaluation:send_reminders` - リマインダーメール送信
-  - `evaluation:send_completion_notifications` - 完了通知送信
-  - `evaluation:stats` - 評価統計表示
-
-### ✅ 10. ドキュメント
-- **ファイル**: `docs/email_notification_system.md`
-- **内容**:
-  - 機能説明
-  - 設定方法
-  - 使用方法
-  - トラブルシューティング
-  - カスタマイズガイド
-
-### ✅ 11. デモスクリプト
-- **ファイル**: `demo_email_system.rb`
-- **機能**: システム動作確認とサンプルデータ生成
+詳細な設定手順やトラブルシューティングは
+[email_notification_system.md](email_notification_system.md) を参照してください。
 
 ## テスト結果
 
@@ -117,47 +40,13 @@ EvaluationMailer.instance_methods(false)
 - 完了通知: http://localhost:3000/rails/mailers/evaluation_mailer/completion_notification
 
 ## 使用方法
-
-### 自動送信（推奨）
-評価参加者追加時に自動的に招待メールが送信されます。
-
-### 手動送信
-```bash
-# リマインダーメール送信
-bundle exec rake evaluation:send_reminders
-
-# 完了通知送信
-bundle exec rake evaluation:send_completion_notifications
-
-# 統計表示
-bundle exec rake evaluation:stats
-```
-
-### デモ実行
-```bash
-rails runner demo_email_system.rb
-```
+メール送信の自動化やRakeタスクの実行方法については
+[email_notification_system.md](email_notification_system.md) を参照してください。
 
 ## 今後の拡張提案
-
-### 1. 自動スケジューリング
-- cron job設定でリマインダーの自動送信
-- GitHub Actions / CI/CDパイプラインでの定期実行
-
-### 2. 配信管理機能
-- 配信停止機能
-- メール配信履歴追跡
-- 配信失敗の再送機能
-
-### 3. カスタマイズ機能
-- 組織ごとのメールテンプレート
-- カスタムブランディング
-- 送信タイミングの設定
-
-### 4. 統計・レポート
-- メール開封率追跡
-- リンククリック率測定
-- 評価参加率とメール配信の相関分析
+メール通知機能の拡張アイデアについては
+[email_notification_system.md](email_notification_system.md) の
+"今後の拡張予定" セクションを参照してください。
 
 ## 技術仕様
 


### PR DESCRIPTION
## Summary
- trim email system implementation report
- link to `email_notification_system.md` for details
- add a note in `AGENTS.md` about keeping branch names in English

## Testing
- `bundle exec rubocop -f simple`
- `bin/brakeman --no-pager`
- `bin/importmap audit`
- `bin/rails test`
- `bin/rails test:system`


------
https://chatgpt.com/codex/tasks/task_e_6840210b396c83299329ab7076721a1d